### PR TITLE
Fix the tests with OCaml 5.2

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -158,13 +158,13 @@ let rfc2047 =
     ; ("Patrick_F=E4ltstr=F6m", "Patrick F\xe4ltstr\xf6m") ]
 
 let qp =
-{qp|J'interdis aux marchands de vanter trop leurs marchandises. Car ils se font=
- vite p=C3=A9dagogues et t'enseignent comme but ce qui n'est par essence qu=
-'un moyen, et te trompant ainsi sur la route =C3=A0 suivre les voil=C3=A0 =
-bient=C3=B4t qui te d=C3=A9gradent, car si leur musique est vulgaire il=
-s te fabriquent pour te la vendre une =C3=A2me vulgaire.            
-   =E2=80=94=E2=80=89Antoine de Saint-Exup=C3=A9ry, Citadelle (1948)
-
+{qp|J'interdis aux marchands de vanter trop leurs marchandises. Car ils se font=|qp}^"\r"^{qp|
+ vite p=C3=A9dagogues et t'enseignent comme but ce qui n'est par essence qu=|qp}^"\r"^{qp|
+'un moyen, et te trompant ainsi sur la route =C3=A0 suivre les voil=C3=A0 =|qp}^"\r"^{qp|
+bient=C3=B4t qui te d=C3=A9gradent, car si leur musique est vulgaire il=|qp}^"\r"^{qp|
+s te fabriquent pour te la vendre une =C3=A2me vulgaire.            |qp}^"\r"^{qp|
+   =E2=80=94=E2=80=89Antoine de Saint-Exup=C3=A9ry, Citadelle (1948)|qp}^"\r"^{qp|
+|qp}^"\r"^{qp|
 |qp}
 
 let citadelle = {unicode|J'interdis aux marchands de vanter trop leurs marchandises. Car ils se font vite pédagogues et t'enseignent comme but ce qui n'est par essence qu'un moyen, et te trompant ainsi sur la route à suivre les voilà bientôt qui te dégradent, car si leur musique est vulgaire ils te fabriquent pour te la vendre une âme vulgaire.


### PR DESCRIPTION
Otherwise the tests fail with:
```
#=== ERROR while compiling pecu.0.6 ===========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/pecu.0.6
# command              ~/.opam/5.2/bin/dune runtest -p pecu -j 1
# exit-code            1
# env-file             ~/.opam/log/pecu-40-503db8.env
# output-file          ~/.opam/log/pecu-40-503db8.out
### output ###
# File "test/dune", line 5, characters 0-129:
# 5 | (alias
# 6 |  (name runtest)
# 7 |  (package pecu)
# 8 |  (deps (:test test.exe) (glob_files "contents/*"))
# 9 |  (action (run %{test} --color=always)))
# (cd _build/default/test && ./test.exe --color=always)
# Testing `pecu'.
# This run has ID `QBBAEDI8'.
# 
#   [OK]          input fuzz          0   contents/id:000000,src:000000,op:havo...
#   [OK]          input fuzz          1   contents/id:000000,src:000050,op:havo...
#   [OK]          input fuzz          2   contents/id:000001,src:000023,op:havo...
#   [OK]          input fuzz          3   contents/id:000001,src:000026+000032,...
#   [OK]          input fuzz          4   contents/id:000002,src:000023,op:havo...
#   [OK]          input fuzz          5   contents/id:000002,src:000063,op:int1...
#   [OK]          input fuzz          6   contents/id:000003,src:000024+000025,...
#   [OK]          input fuzz          7   contents/id:000003,src:000055,op:havo...
#   [OK]          input fuzz          8   contents/id:000004,src:000037+000000,...
# > [FAIL]        simple              0   simple example.
#   [OK]          simple              1   split at cr.
#   [OK]          rfc2047             0   rfc2047:0.
#   [OK]          rfc2047             1   rfc2047:1.
#   [OK]          rfc2047             2   rfc2047:2.
#   [OK]          rfc2047             3   rfc2047:3.
#   [OK]          rfc2047             4   rfc2047:4.
#   [OK]          rfc2047             5   rfc2047:5.
#   [OK]          rfc2047             6   rfc2047:6.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        simple              0   simple example.                        │
# └──────────────────────────────────────────────────────────────────────────────┘
# ASSERT =
#  
# FAIL =
#  
# Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
# Called from Test.simple.(fun) in file "test/test.ml", line 189, characters 15-49
# Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
# Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
# 
# Logs saved to `~/.opam/5.2/.opam-switch/build/pecu.0.6/_build/default/test/_build/_tests/pecu/simple.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/pecu.0.6/_build/default/test/_build/_tests/pecu'.
# 1 failure! in 0.002s. 18 tests run.
```
The reason behind this required change is that https://github.com/ocaml/ocaml/pull/12514 changed the way OCaml source files are parsed and `{| ... |}` strings containing `\r+\n` are not parsed the same now. To that end making the `\r` explicit is a reasonable change I feel.